### PR TITLE
[Resubmit] Remove all .idea directories from Git tracking and update .gitignore

### DIFF
--- a/source/did-client-sdk-aos/.gitignore
+++ b/source/did-client-sdk-aos/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+**/.idea/


### PR DESCRIPTION
## Description  
This pull request ensures that all JetBrains IDE configuration folders (`.idea/`) are no longer tracked by Git and updates the project’s `.gitignore` accordingly.  
- Added `**/.idea/` to `.gitignore` to recursively ignore all `.idea` directories.  
- Removed any existing `.idea` folders from tracking without deleting them locally.

## Related Issue (Optional)  
- Closes #7

## Changes  
- **.gitignore**: Added `**/.idea/` entry.  
- Executed `git rm -r --cached .idea` (and similar commands) to untrack all previously tracked `.idea` directories across the repository.

## Screenshots (Optional)  
N/A

## Additional Comments (Optional)  
**Note:** This is a resubmission of PR #7 after the develop branch was hard reset.

If any `.idea` folders remain tracked after merging, please run the following to clear cached entries:  
```bash
find . -type d -name ".idea" -exec git rm -r --cached {} +
```